### PR TITLE
(feature) Post email: Add link to post in title

### DIFF
--- a/sample/themes/laurel/templates/emails/post.html
+++ b/sample/themes/laurel/templates/emails/post.html
@@ -2,6 +2,7 @@
 
 --><div style="font-size: 16px; line-height: 18px; font-family: Helvetica; min-width: 100px; max-width: 800px; margin: 0; margin-left: auto; margin-right: auto; background-color: #FFF; padding: 0; border-radius: 3px;"><!--
 
+	-->{{ $host := .Host }}<!--
 	--><div style="margin: 0; padding: 10px; background-color: #3b304e; border-top-right-radius: 3px; border-top-left-radius: 3px;"><!--
 		--><table style="margin: 0; padding: 0; border: none; border-collapse: collapse;"><!--
 			--><tr style="margin: 0; padding: 0"><!--
@@ -9,14 +10,13 @@
 					--><img style="margin: 0; padding: 0; border: none; outline: none; width: 80px; height: 80px; border-radius: 3px;" src="{{ .Host }}/theme/img/laurel-avatar.jpg"/><!--
 				--></td><!--
 				--><td style="margin: 0; padding: 0; padding-left: 20px;"><!--
-					--><h1 style="margin: 0; color: #45c5d2">{{ .Post.Title }}</h1><!--
+					--><a style="text-decoration: none" clicktracking=off href="{{ $host }}/post/{{ .Post.Slug }}/{{ .Post.ID }}"><h1 style="margin: 0; color: #45c5d2 ">{{ .Post.Title }}</h1></a><!--
 				--></td><!--
 			--></tr><!--
 		--></table><!--
 	--></div><!--
 
 	--><div style="margin: 0; padding: 20px;"><!--
-		-->{{ $host := .Host }}<!--
 		-->{{ range .Post.Blocks }}<!--
 		-->{{ if eq .type "text" }}<!--
 				--><div style="margin: 0; padding: 0; padding-bottom: 20px;">{{ .text }}</div><!--

--- a/sample/themes/laurel/templates/emails/post.txt
+++ b/sample/themes/laurel/templates/emails/post.txt
@@ -1,6 +1,6 @@
-{{ .Post.Title }}
-
 {{ $host := .Host }}
+{{ .Post.Title }}: {{ $host }}/post/{{ .Post.Slug }}/{{ .Post.ID }}
+
 {{ range .Post.Blocks }}
 	{{ if eq .type "text" }}
 		{{ .text }}


### PR DESCRIPTION
Hi !

First, good job for this whole project. I've been playing around with it for the last days, and it's very complete. In addition to the post and comments features, I also tried the rss and email features, and it all works very well.
At first, it was a little hard to get started with it, but considering it is a personal project, it doesn't really matter.

As I was playing with the newsletter feature, I thought it would be a good idea to add a link to the post inside the title. This is the object of this PR.
It's a really simple feature as far as coding, but I think it's quite a cool one for blog users.
There is already a link to the comment section of the post, at the bottom of the email, but not to the post itself. Email readers are quite often bad at rendering a post, so it's cool to be able to open it in the browser in one click.

I am new to Golang (including its HTML template syntax) so feel free to review my code, even if it is very simple.
A few notes :
- I modified both the HTML and the plain-text versions of the email. (post.html, post.txt)
- I had to move up the declaration of the `$host` a bit, to use it in the link.
- I added the `text-decoration: none` to the `<a>`, to prevent some ugly underlining by some email readers. I would have liked to have some "underline on hover only" but I think it cannot be done with sendgrid, so I just completely removed text decoration.
- By the way, I think the `<style>` tag at the beginning of `post.html` is ignored. I tried playing around 
with it and it never changed anything to the sent email. (but it's not the point of this PR)

Voilà!
It's a really simple feature, but if you want to accept it, I'll be glad to have contributed a bit to this cool project.

Bye
